### PR TITLE
fix broken formatting

### DIFF
--- a/blueprint/index.md
+++ b/blueprint/index.md
@@ -6,7 +6,7 @@ icon: blueprint
 image: images/flowchart.png
 category: 6
 summary: |
-This Genesys Blueprint provides instructions for deploying a chat assistant on Genesys Cloud. The Chat Assistant actively listens to the chat interaction and suggest responses based on keywords. Sending messages and the typing indicator features of the Chat API will be convenient in this scenario.
+  This Genesys Blueprint provides instructions for deploying a chat assistant on Genesys Cloud. The Chat Assistant actively listens to the chat interaction and suggest responses based on keywords. Sending messages and the typing indicator features of the Chat API will be convenient in this scenario.
 ---
 :::{"alert":"primary","title":"About Genesys Cloud Blueprints","autoCollapse":false} 
 Genesys Cloud blueprints were built to help you jump-start building an application or integrating with a third-party partner. 


### PR DESCRIPTION
A previous PR (https://github.com/GenesysCloudBlueprints/chat-assistant-blueprint/pull/8/files#diff-0f3c29944bce4494eab2cf1b4ac6771707d23bb133cda87e5a1a9d6d9c6f558bL9) introduced invalid formatting in the frontmatter and broke the dev center build. This PR fixes it. 

@AgnesCorpuz @amallen02  For future reference, the frontmatter's formatting can be checked when viewing/previewing the page: https://github.com/GenesysCloudBlueprints/chat-assistant-blueprint/blob/master/blueprint/index.md. Github shows YAML parsing errors:

<img width="1282" alt="image" src="https://user-images.githubusercontent.com/74417894/211609015-4195b3ec-6599-483e-b307-19b75c2d18b7.png">
